### PR TITLE
Updating hackclub.com yaml with custom subdomain

### DIFF
--- a/hackclub.com.yaml
+++ b/hackclub.com.yaml
@@ -385,6 +385,10 @@ coins:
 - ttl: 1
   type: A
   value: 173.208.140.124
+conant:
+- ttl: 1
+  type: CNAME
+  value: ashayp22.github.io.
 ctf:
 - ttl: 1
   type: CNAME


### PR DESCRIPTION
Adding conant.hackclub.com for the Conant High School Hack Club website.